### PR TITLE
Fix: compatibility problem on python3.6

### DIFF
--- a/htmloutput/htmloutput.py
+++ b/htmloutput/htmloutput.py
@@ -493,7 +493,7 @@ class HtmlOutput(Plugin):
 
     def formatErr(self, err):
         exctype, value, tb = err
-        return ''.join(traceback.format_exception(exctype, value, tb))
+        return ''.join(traceback.format_tb(tb))
 
     def setOutputStream(self, stream):
         # grab for Monitoring


### PR DESCRIPTION
Latest version can't now run on latest ceph/s3tests because of some compatibility problem of python version.

```
exctype, value, tb = err
return ''.join(traceback.format_exception(exctype, value, tb))
```

Value is a string type. But traceback.format_exception refuse to accept
a string as its second parameter in python 3.6

> AttributeError: 'str' object has no attribute '__cause__'

Maybe we can use traceback.format_tb instead of format_exception. The output of
the two function are almost the same.

Signed-off-by: Pei <huangp0600@126.com>